### PR TITLE
Allow use of different case for model class name and column name 

### DIFF
--- a/src/config/IConfig.ts
+++ b/src/config/IConfig.ts
@@ -2,6 +2,14 @@ import { Options } from 'sequelize';
 import { CLIEngine } from 'eslint';
 
 export type TransformCase = 'UPPER' | 'LOWER' | 'UNDERSCORE' | 'CAMEL' | 'PASCAL' | 'CONST';
+export enum TransformType {
+    MODEL = 'model',
+    COLUMN = 'column'
+};
+export type TransformCollection = {
+    [key in TransformType]: TransformCase;
+};
+export type TransformFunction = (value: string, type: TransformType) => string;
 
 export const TransformCases = new Set<TransformCase>([
     'UPPER',
@@ -18,7 +26,7 @@ export interface IConfigMetadata {
     skipTables?: string[];
     indices?: boolean;
     timestamps?: boolean;
-    case?: TransformCase;
+    case?: TransformCase | TransformCollection | TransformFunction;
     associationsFile?: string;
 }
 

--- a/src/tests/integration/TestRunner.ts
+++ b/src/tests/integration/TestRunner.ts
@@ -10,7 +10,7 @@ import { IConfig } from '../../config';
 import { Dialect } from '../../dialects/Dialect';
 import { getTransformer } from '../../dialects/utils';
 import { ModelBuilder } from '../../builders';
-import { TransformCase, TransformCases } from '../../config/IConfig';
+import { TransformCase, TransformCases, TransformType } from '../../config/IConfig';
 import {
     DialectMySQL,
     DialectPostgres,
@@ -307,7 +307,7 @@ export class TestRunner {
                         const transformer = getTransformer(transformCase);
 
                         for (const { name: tableName } of testTables) {
-                            await fs.access(path.join(outDir, transformer(tableName) + '.ts'));
+                            await fs.access(path.join(outDir, transformer(tableName, TransformType.MODEL) + '.ts'));
                         }
 
                         // TODO problem with models registration due to 'require(path/to/module)'


### PR DESCRIPTION
Sometimes it's helpful to be able to use different cases for the generated class names and the column names or supply own transform function in programmatic usage.

Method 1 (Current):
```typescript
metadata: {
     case:  'PASCAL',
      ...
 }
```

Method 2 (Pass an object -TransformCollection):
```typescript
metadata: {
     case: {
         model: 'PASCAL',
         column: 'LOWER'
      },
      ...
 }
```

Method 3 (Pass custom TransformFunction):
```typescript
metadata: {
     case: (value: string, type: TransformType) => {
               if(type === TransformType.MODEL){
                     // return something
               }
              // return something else
     },
      ...
 }
```