### PR TITLE
Added missing spatial data types to MSSQL and Postgres dialects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sequelize-typescript-generator",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sequelize-typescript-generator",
-      "version": "9.0.1",
+      "version": "9.0.2",
       "license": "ISC",
       "dependencies": {
         "@types/eslint": "^8.4.10",
@@ -45,7 +45,7 @@
         "typescript": "^4.9.3"
       }
     },
-    "../../../../../../jest@28": {
+    "../../../../../jest@28": {
       "extraneous": true
     },
     "node_modules/@ampproject/remapping": {

--- a/src/dialects/DialectMSSQL.ts
+++ b/src/dialects/DialectMSSQL.ts
@@ -115,6 +115,7 @@ const sequelizeDataTypesMap: { [key: string]: AbstractDataTypeConstructor } = {
     varbinary: DataType.STRING,
     uniqueidentifier: DataType.STRING,
     xml: DataType.STRING,
+    geography: DataType.GEOGRAPHY,
 };
 
 /**

--- a/src/dialects/DialectMySQL.ts
+++ b/src/dialects/DialectMySQL.ts
@@ -86,7 +86,6 @@ const sequelizeDataTypesMap: { [key: string]: AbstractDataTypeConstructor } = {
     geometry: DataType.GEOMETRY,
     geometrycollection: DataType.GEOMETRY,
     json: DataType.JSON,
-    geography: DataType.GEOGRAPHY,
 };
 
 const jsDataTypesMap: { [key: string]: string } = {

--- a/src/dialects/DialectMySQL.ts
+++ b/src/dialects/DialectMySQL.ts
@@ -86,6 +86,7 @@ const sequelizeDataTypesMap: { [key: string]: AbstractDataTypeConstructor } = {
     geometry: DataType.GEOMETRY,
     geometrycollection: DataType.GEOMETRY,
     json: DataType.JSON,
+    geography: DataType.GEOGRAPHY,
 };
 
 const jsDataTypesMap: { [key: string]: string } = {

--- a/src/dialects/DialectPostgres.ts
+++ b/src/dialects/DialectPostgres.ts
@@ -106,7 +106,6 @@ const sequelizeDataTypesMap: { [key: string]: AbstractDataTypeConstructor } = {
     json: DataType.JSON,
     jsonb: DataType.JSONB,
     jsonpath: DataType.JSON,
-    geography: DataType.GEOGRAPHY,
     geometry: DataType.GEOMETRY,
 }
 

--- a/src/dialects/DialectPostgres.ts
+++ b/src/dialects/DialectPostgres.ts
@@ -106,6 +106,7 @@ const sequelizeDataTypesMap: { [key: string]: AbstractDataTypeConstructor } = {
     json: DataType.JSON,
     jsonb: DataType.JSONB,
     jsonpath: DataType.JSON,
+    geography: DataType.GEOGRAPHY,
 }
 
 const jsDataTypesMap: { [key: string]: string } = {

--- a/src/dialects/DialectPostgres.ts
+++ b/src/dialects/DialectPostgres.ts
@@ -107,6 +107,7 @@ const sequelizeDataTypesMap: { [key: string]: AbstractDataTypeConstructor } = {
     jsonb: DataType.JSONB,
     jsonpath: DataType.JSON,
     geography: DataType.GEOGRAPHY,
+    geometry: DataType.GEOMETRY,
 }
 
 const jsDataTypesMap: { [key: string]: string } = {


### PR DESCRIPTION
Added missing spatial data types to [MSSQL](https://learn.microsoft.com/en-us/sql/relational-databases/spatial/spatial-data-sql-server?view=sql-server-ver16) and [Postgres](https://www.postgresql.org/docs/current/datatype-geometric.html).