### PR TITLE
feat: add support for association methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "sequelize-typescript-generator",
-  "version": "11.0.8",
+  "name": "@jsindos/sequelize-typescript-generator",
+  "version": "11.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sequelize-typescript-generator",
-      "version": "11.0.8",
+      "name": "@jsindos/sequelize-typescript-generator",
+      "version": "11.0.16",
       "license": "ISC",
       "dependencies": {
         "@types/eslint": "^8.56.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sequelize-typescript-generator",
-  "version": "11.0.8",
+  "name": "@jsindos/sequelize-typescript-generator",
+  "version": "11.0.9",
   "description": "Automatically generates typescript models compatible with sequelize-typescript library (https://www.npmjs.com/package/sequelize-typescript) directly from your source database.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsindos/sequelize-typescript-generator",
-  "version": "11.0.13",
+  "version": "11.0.16",
   "description": "Automatically generates typescript models compatible with sequelize-typescript library (https://www.npmjs.com/package/sequelize-typescript) directly from your source database.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsindos/sequelize-typescript-generator",
-  "version": "11.0.12",
+  "version": "11.0.13",
   "description": "Automatically generates typescript models compatible with sequelize-typescript library (https://www.npmjs.com/package/sequelize-typescript) directly from your source database.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsindos/sequelize-typescript-generator",
-  "version": "11.0.16",
+  "version": "11.1.1",
   "description": "Automatically generates typescript models compatible with sequelize-typescript library (https://www.npmjs.com/package/sequelize-typescript) directly from your source database.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsindos/sequelize-typescript-generator",
-  "version": "11.0.9",
+  "version": "11.0.10",
   "description": "Automatically generates typescript models compatible with sequelize-typescript library (https://www.npmjs.com/package/sequelize-typescript) directly from your source database.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsindos/sequelize-typescript-generator",
-  "version": "11.0.10",
+  "version": "11.0.11",
   "description": "Automatically generates typescript models compatible with sequelize-typescript library (https://www.npmjs.com/package/sequelize-typescript) directly from your source database.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsindos/sequelize-typescript-generator",
-  "version": "11.0.11",
+  "version": "11.0.12",
   "description": "Automatically generates typescript models compatible with sequelize-typescript library (https://www.npmjs.com/package/sequelize-typescript) directly from your source database.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/builders/ModelBuilder.ts
+++ b/src/builders/ModelBuilder.ts
@@ -94,37 +94,46 @@ export class ModelBuilder extends Builder {
      * @param {IAssociationMetadata} association
      */
     private static buildAssociationPropertyDecl(association: IAssociationMetadata, tablesMetadata: ITablesMetadata): ts.PropertyDeclaration[] {
-        const { associationName, targetModel, joinModel } = association;
-
+        const { associationName, targetModel, joinModel, alias } = association;
+    
         const targetModels = [ targetModel ];
         joinModel && targetModels.push(joinModel);
-
+    
+        // Use alias if provided, otherwise use target model name
+        const nameBase = alias || targetModel;
+        const propertyName = associationName.includes('Many') ?
+            pluralize.plural(nameBase) : pluralize.singular(nameBase);
+    
+        let decorator;
+        if (associationName === 'BelongsToMany') {
+            // For BelongsToMany, don't pass alias in decorator options
+            // The alias will be handled by the property name
+            decorator = generateArrowDecorator(associationName, targetModels);
+        } else {
+            // For other associations, pass options normally
+            const options = {
+                ...(association.sourceKey && { sourceKey: association.sourceKey }),
+                ...(alias && { as: alias })
+            };
+            decorator = generateArrowDecorator(
+                associationName, 
+                targetModels, 
+                Object.keys(options).length > 0 ? options : undefined
+            );
+        }
+    
         const mainProperty = ts.factory.createPropertyDeclaration(
-            [
-                ...(association.sourceKey ?
-                        [
-                            generateArrowDecorator(
-                                associationName,
-                                targetModels,
-                                { sourceKey: association.sourceKey }
-                            )
-                        ]
-                        : [
-                            generateArrowDecorator(associationName, targetModels)
-                        ]
-                ),
-            ],
-            associationName.includes('Many') ?
-                pluralize.plural(targetModel) : pluralize.singular(targetModel),
+            [decorator],
+            propertyName,
             ts.factory.createToken(ts.SyntaxKind.QuestionToken),
             associationName.includes('Many') ?
                 ts.factory.createArrayTypeNode(ts.factory.createTypeReferenceNode(targetModel, undefined)) :
                 ts.factory.createTypeReferenceNode(targetModel, undefined),
             undefined,
         );
-
+    
         const mixinDeclarations = this.generateAssociationMixins(association, tablesMetadata);
-
+    
         return [mainProperty, ...mixinDeclarations];
     }
 
@@ -138,10 +147,13 @@ export class ModelBuilder extends Builder {
         );
     }
 
-    private static generateAssociationMixins(association: IAssociationMetadata,     tablesMetadata: ITablesMetadata): ts.PropertyDeclaration[] {
-        const { associationName, targetModel } = association;
-        const singularTarget = pluralize.singular(targetModel);
-        const pluralTarget = pluralize.plural(targetModel);
+    private static generateAssociationMixins(association: IAssociationMetadata, tablesMetadata: ITablesMetadata): ts.PropertyDeclaration[] {
+        const { associationName, targetModel, alias } = association;
+        
+        // Use alias if provided, otherwise use target model name
+        const nameBase = alias || targetModel;
+        const singularTarget = pluralize.singular(nameBase);
+        const pluralTarget = pluralize.plural(nameBase);
     
         // Get the primary key type from the target table's metadata
         const targetTable = tablesMetadata[targetModel];
@@ -149,7 +161,7 @@ export class ModelBuilder extends Builder {
         const primaryKeyType = primaryKeyColumn ? 
             this.getPrimaryKeyType(primaryKeyColumn.type) : 
             'number';  // fallback to number if not found
-
+    
         switch (associationName) {
             case 'HasMany':
                 return [

--- a/src/builders/ModelBuilder.ts
+++ b/src/builders/ModelBuilder.ts
@@ -82,7 +82,7 @@ export class ModelBuilder extends Builder {
                 )
             ],
             col.name,
-            (col.autoIncrement || col.allowNull || col.defaultValue !== undefined) ?
+            (col.autoIncrement || col.allowNull) ?
                 ts.factory.createToken(ts.SyntaxKind.QuestionToken) : ts.factory.createToken(ts.SyntaxKind.ExclamationToken),
             ts.factory.createTypeReferenceNode(dialect.mapDbTypeToJs(col.type) ?? 'any', undefined),
             undefined,

--- a/src/builders/ModelBuilder.ts
+++ b/src/builders/ModelBuilder.ts
@@ -328,7 +328,7 @@ generatedCode += '\n';
                     ...(Object.values(columns).map(c => ts.factory.createPropertySignature(
                         undefined,
                         ts.factory.createIdentifier(c.name),
-                        c.autoIncrement || c.allowNull || c.defaultValue !== undefined ?
+                        c.name === 'id' || c.autoIncrement || c.allowNull || c.defaultValue !== undefined ?
                             ts.factory.createToken(ts.SyntaxKind.QuestionToken) : undefined,
                         ts.factory.createTypeReferenceNode(dialect.mapDbTypeToJs(c.type) ?? 'any', undefined)
                     )))

--- a/src/dialects/AssociationsParser.ts
+++ b/src/dialects/AssociationsParser.ts
@@ -13,7 +13,9 @@ type AssociationRow = [
     string, // right key
     string, // left table
     string, // right table
-    string? // [join table]
+    string?, // [join table]
+    string?, // [left alias] - alias used by leftModel when referring to rightModel
+    string? // [right alias] - alias used by rightModel when referring to leftModel
 ];
 
 export interface IAssociationMetadata {
@@ -21,6 +23,7 @@ export interface IAssociationMetadata {
     targetModel: string;
     joinModel?: string;
     sourceKey?: string; // Left table key for HasOne and HasMany associations
+    alias?: string; // Optional alias for the association
 }
 
 export interface IForeignKey {
@@ -42,7 +45,9 @@ const validateRow = (row: AssociationRow): void => {
         rightKey,
         leftTable,
         rightTable,
-        joinTable
+        joinTable,
+        leftAlias,
+        rightAlias
     ] = row;
 
     if (!cardinalities.has(cardinality)) {
@@ -67,6 +72,15 @@ const validateRow = (row: AssociationRow): void => {
 
     if (cardinality === 'N:N' && (!joinTable || !joinTable.length)) {
         throw new Error(`Association N:N requires a joinTable in the association row`);
+    }
+
+    // Validate aliases are not empty strings if provided
+    if (leftAlias !== undefined && leftAlias.length === 0) {
+        throw new Error(`Left alias cannot be empty string. Use undefined or omit the field instead.`);
+    }
+
+    if (rightAlias !== undefined && rightAlias.length === 0) {
+        throw new Error(`Right alias cannot be empty string. Use undefined or omit the field instead.`);
     }
 }
 
@@ -109,7 +123,9 @@ export class AssociationsParser {
                 rightKey,
                 leftModel,
                 rightModel,
-                joinModel
+                joinModel,
+                leftAlias,
+                rightAlias
             ] = row;
 
             const [
@@ -135,15 +151,19 @@ export class AssociationsParser {
 
             // 1:1 and 1:N association
             if (cardinality !== 'N:N') {
+                // Left model association (HasOne/HasMany)
                 associationsMetadata[leftModel].associations.push({
                     associationName: rightCardinality === '1' ? 'HasOne' : 'HasMany',
                     targetModel: rightModel,
                     sourceKey: leftKey,
+                    ...(leftAlias && { alias: leftAlias })
                 });
 
+                // Right model association (BelongsTo)
                 associationsMetadata[rightModel].associations.push({
                     associationName: 'BelongsTo',
                     targetModel: leftModel,
+                    ...(rightAlias && { alias: rightAlias })
                 });
 
                 associationsMetadata[rightModel].foreignKeys.push({
@@ -161,16 +181,20 @@ export class AssociationsParser {
                     };
                 }
 
+                // Left model BelongsToMany association
                 associationsMetadata[leftModel].associations.push({
                     associationName: 'BelongsToMany',
                     targetModel: rightModel,
                     joinModel: joinModel,
+                    ...(leftAlias && { alias: leftAlias })
                 });
 
+                // Right model BelongsToMany association
                 associationsMetadata[rightModel].associations.push({
                     associationName: 'BelongsToMany',
                     targetModel: leftModel,
                     joinModel: joinModel,
+                    ...(rightAlias && { alias: rightAlias })
                 });
 
                 associationsMetadata[joinModel!].foreignKeys.push({

--- a/src/dialects/DialectPostgres.ts
+++ b/src/dialects/DialectPostgres.ts
@@ -305,7 +305,7 @@ export class DialectPostgres extends Dialect {
                         this.mapDbTypeToSequelize(column.udt_name).key
                             .split(' ')[0], // avoids 'DOUBLE PRECISION' key to include PRECISION in the mapping
                 },
-                allowNull: !!column.is_nullable && !column.is_primary,
+                allowNull: column.is_nullable === 'YES' && !column.is_primary,
                 primaryKey: column.is_primary,
                 autoIncrement: column.is_sequence,
                 indices: [],


### PR DESCRIPTION
This PR adds support for sequelize association methods, as per

- https://github.com/sequelize/sequelize/issues/14637
- https://sequelize.org/docs/v6/other-topics/typescript/

For example, when providing the association csv, we will also get the following properties added (from the `person <-> passport` test data):

```
    declare getPassport: HasOneGetAssociationMixin<passport>;

    declare setPassport: HasOneSetAssociationMixin<passport, number>;

    declare createPassport: HasOneCreateAssociationMixin<passport>;
```

Note the following hasn't been added / run:

- linting
  - I ran `npm run lint` but get the following output, wondering if I can get some help on how to run automatic eslint fix on my changes using the project configuration
```
> sequelize-typescript-generator@11.0.8 lint
> eslint --fix --ext .ts output/*.ts


Oops! Something went wrong! :(

ESLint: 8.57.0

No files matching the pattern "output/*.ts" were found.
Please check for typing mistakes in the pattern.
```

- tests
  - I can run the tests and they all pass, but wasn't sure where to add testing for the new functionality. I looked into `it('1:1', async () => {` but it seems these tests are on the Sequelize models themselves, rather than the generated types.
  
- import statements
  - The import statements for the new Mixins are always added, should these instead be added conditionally or will linting clean this up automatically?